### PR TITLE
feat: 플레이어 로그인 API 추가 및 필요 스키마 추가

### DIFF
--- a/apps/auth/src/module/authorization/authorization.controller.ts
+++ b/apps/auth/src/module/authorization/authorization.controller.ts
@@ -15,6 +15,11 @@ import {
   UpdateRoleResponseDto,
 } from '@libs/interfaces/auth/update_role.dto';
 import { ITokenPayload } from '@libs/interfaces/payload/payload.interface';
+import {
+  PlayerLoginRequestDto,
+  PlayerLoginResponseDto,
+} from '@libs/interfaces/auth/player_login.dto';
+import { Player } from '@libs/database/schemas/player.schema';
 
 @Controller()
 export class AuthorizationController {
@@ -47,6 +52,18 @@ export class AuthorizationController {
     return {
       targetEmail: result.email,
       targetRole: result.role,
+    };
+  }
+  @MessagePattern('playerLogin')
+  async loginPlayer(
+    param: PlayerLoginRequestDto
+  ): Promise<PlayerLoginResponseDto> {
+    const result: Partial<Player> & { token: string } =
+      await this.authService.loginPlayer(param);
+    return {
+      nickname: result.nickname,
+      metadata: result.metadata,
+      token: result.token,
     };
   }
 }

--- a/apps/auth/src/module/authorization/authorization.module.ts
+++ b/apps/auth/src/module/authorization/authorization.module.ts
@@ -4,16 +4,18 @@ import { AuthorizationService } from './authorization.service';
 import { AdminModelModule } from '../database/model/admin/admin.model.module';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import { PlayerModelModule } from '../database/model/player/player.model.module';
 
 @Module({
   imports: [
-    AdminModelModule,
     JwtModule.registerAsync({
       useFactory: (configService: ConfigService) => ({
         secret: configService.get('jwtSecret'),
       }),
       inject: [ConfigService],
     }),
+    AdminModelModule,
+    PlayerModelModule,
   ],
   controllers: [AuthorizationController],
   providers: [AuthorizationService],

--- a/apps/auth/src/module/database/model/player/player.model.module.ts
+++ b/apps/auth/src/module/database/model/player/player.model.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PlayerModelService } from './player.model.service';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Player, PlayerSchema } from '@libs/database/schemas/player.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Player.name, schema: PlayerSchema }]),
+  ],
+  controllers: [],
+  providers: [PlayerModelService],
+  exports: [PlayerModelService],
+})
+export class PlayerModelModule {}

--- a/apps/auth/src/module/database/model/player/player.model.service.ts
+++ b/apps/auth/src/module/database/model/player/player.model.service.ts
@@ -1,0 +1,19 @@
+import { BaseModelService } from '@libs/database/model/base.model';
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Player, PlayerDocument } from '@libs/database/schemas/player.schema';
+
+@Injectable()
+export class PlayerModelService extends BaseModelService<PlayerDocument> {
+  constructor(
+    @InjectModel(Player.name)
+    private readonly playerModel: Model<PlayerDocument>
+  ) {
+    super(playerModel);
+  }
+
+  async findByNickname(nickname: string): Promise<PlayerDocument | null> {
+    return this.playerModel.findOne({ nickname }).exec();
+  }
+}

--- a/apps/gateway/src/module/router/auth/auth.controller.ts
+++ b/apps/gateway/src/module/router/auth/auth.controller.ts
@@ -17,6 +17,10 @@ import {
 } from '@libs/interfaces/auth/update_role.dto';
 import { VerifiedPayload } from '../../../common/decorator/payload.decorator';
 import { ITokenPayload } from '@libs/interfaces/payload/payload.interface';
+import {
+  PlayerLoginRequestDto,
+  PlayerLoginResponseDto,
+} from '@libs/interfaces/auth/player_login.dto';
 
 @Controller('auth')
 export class AuthRouterController {
@@ -86,6 +90,27 @@ export class AuthRouterController {
     };
     const response: UpdateRoleResponseDto =
       await this.authRouterService.updateRole(param);
+    return response;
+  }
+
+  @Post('login_player')
+  @ApiOperation({
+    summary: '플레이어 게스트 로그인 API',
+    description: '플레이어 로그인(닉네임 중복 없을 시 자동가입)',
+  })
+  @ApiBody({ type: PlayerLoginRequestDto })
+  @ApiResponse({
+    status: 200,
+    description: '플레이어 로그인 성공',
+    type: PlayerLoginResponseDto,
+  })
+  @IgnoreAuthGuard()
+  public async loginPlayer(
+    @Body() body: PlayerLoginRequestDto
+  ): Promise<PlayerLoginResponseDto> {
+    const param: PlayerLoginRequestDto = body;
+    const response: PlayerLoginResponseDto =
+      await this.authRouterService.loginPlayer(param);
     return response;
   }
 }

--- a/apps/gateway/src/module/router/auth/auth.service.ts
+++ b/apps/gateway/src/module/router/auth/auth.service.ts
@@ -14,38 +14,61 @@ import {
   UpdateRoleResponseDto,
 } from '@libs/interfaces/auth/update_role.dto';
 import { ITokenPayload } from '@libs/interfaces/payload/payload.interface';
+import {
+  PlayerLoginRequestDto,
+  PlayerLoginResponseDto,
+} from '@libs/interfaces/auth/player_login.dto';
 
 @Injectable()
 export class AuthRouterService {
   constructor(@Inject('AUTH_SERVICE') private authClientProxy: ClientProxy) {}
 
+  /**
+   * Auth 마이크로서비스로 요청 전송 제네릭 함수
+   */
+  private async sendAuthServiceRequest<TParam, TResponse>(
+    pattern: string,
+    param: TParam
+  ): Promise<TResponse> {
+    const result = await firstValueFrom(
+      this.authClientProxy.send<TResponse>(pattern, param)
+    );
+    return result;
+  }
+
   async adminLogin(
     param: AdminLoginRequestDto
   ): Promise<AdminLoginResponseDto> {
-    const pattern = 'adminLogin';
-    const result = await firstValueFrom(
-      this.authClientProxy.send<AdminLoginResponseDto>(pattern, param)
-    );
-    return result;
+    return this.sendAuthServiceRequest<
+      AdminLoginRequestDto,
+      AdminLoginResponseDto
+    >('adminLogin', param);
   }
 
   async adminRegistration(
     param: AdminRegRequestDto
   ): Promise<AdminRegResponseDto> {
-    const pattern = 'adminRegistration';
-    const result = await firstValueFrom(
-      this.authClientProxy.send<AdminRegResponseDto>(pattern, param)
+    return this.sendAuthServiceRequest<AdminRegRequestDto, AdminRegResponseDto>(
+      'adminRegistration',
+      param
     );
-    return result;
   }
 
   async updateRole(
     param: ITokenPayload & UpdateRoleRequestDto
   ): Promise<UpdateRoleResponseDto> {
-    const pattern = 'updateRole';
-    const result = await firstValueFrom(
-      this.authClientProxy.send<UpdateRoleResponseDto>(pattern, param)
-    );
-    return result;
+    return this.sendAuthServiceRequest<
+      ITokenPayload & UpdateRoleRequestDto,
+      UpdateRoleResponseDto
+    >('updateRole', param);
+  }
+
+  async loginPlayer(
+    param: PlayerLoginRequestDto
+  ): Promise<PlayerLoginResponseDto> {
+    return this.sendAuthServiceRequest<
+      PlayerLoginRequestDto,
+      PlayerLoginResponseDto
+    >('playerLogin', param);
   }
 }

--- a/libs/constants/src/reward.role.ts
+++ b/libs/constants/src/reward.role.ts
@@ -1,0 +1,6 @@
+export const RewardReceiveMap = {
+  MANUAL: 0,
+  AUTOMATIC: 1,
+} as const;
+export const RewardReceiveList = Object.values(RewardReceiveMap);
+export type RewardReceiveType = (typeof RewardReceiveList)[number];

--- a/libs/database/src/schemas/admin.schema.ts
+++ b/libs/database/src/schemas/admin.schema.ts
@@ -1,6 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, HydratedDocument } from 'mongoose';
-import { AdminRole } from '@libs/constants/index';
+import { AdminRole, AdminRoleMap } from '@libs/constants/index';
 
 export type AdminDocument = HydratedDocument<Admin>;
 
@@ -15,7 +15,7 @@ export class Admin extends Document {
   @Prop({ type: String, required: true })
   name!: string;
 
-  @Prop({ type: Number, required: true })
+  @Prop({ type: Number, required: true, default: AdminRoleMap.NONE })
   role!: AdminRole;
 
   @Prop({ type: Date, default: null })

--- a/libs/database/src/schemas/attendance_reward.schema.ts
+++ b/libs/database/src/schemas/attendance_reward.schema.ts
@@ -1,0 +1,22 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, HydratedDocument } from 'mongoose';
+
+export type AttendanceRewardDocument = HydratedDocument<AttendanceReward>;
+
+@Schema({ timestamps: true })
+export class AttendanceReward extends Document {
+  @Prop({ type: Number, index: true, required: true })
+  eventId!: number;
+
+  @Prop({ type: String, required: true })
+  playerId!: string;
+
+  @Prop({ type: Boolean, required: true })
+  received!: boolean;
+
+  @Prop({ type: Object, default: {} })
+  metadata!: Record<string, any>;
+}
+
+export const AttendanceRewardSchema =
+  SchemaFactory.createForClass(AttendanceReward);

--- a/libs/database/src/schemas/event.schema.ts
+++ b/libs/database/src/schemas/event.schema.ts
@@ -1,0 +1,38 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, HydratedDocument } from 'mongoose';
+import dayjs from 'dayjs';
+import {
+  RewardReceiveMap,
+  RewardReceiveType,
+} from '@libs/constants/reward.role';
+
+export type EventDocument = HydratedDocument<Event>;
+
+@Schema({ timestamps: true })
+export class Event extends Document {
+  @Prop({ type: Number, index: true, required: true })
+  eventId!: number;
+
+  @Prop({ type: String, required: true })
+  eventName!: string;
+
+  @Prop({ type: Date, required: true, default: () => dayjs().toDate() })
+  startDate!: Date;
+
+  @Prop({ type: Date, required: true, default: () => dayjs().toDate() })
+  endDate!: Date;
+
+  @Prop({ type: String, required: true })
+  creator!: string;
+
+  @Prop({ type: Boolean, default: false })
+  isActive!: boolean;
+
+  @Prop({ type: Number, default: RewardReceiveMap.MANUAL })
+  rewardReceiveType!: RewardReceiveType;
+
+  @Prop({ type: Object, default: {} })
+  metadata!: Record<string, any>;
+}
+
+export const EventSchema = SchemaFactory.createForClass(Event);

--- a/libs/database/src/schemas/item.schema.ts
+++ b/libs/database/src/schemas/item.schema.ts
@@ -1,0 +1,18 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, HydratedDocument } from 'mongoose';
+
+export type ItemDocument = HydratedDocument<Item>;
+
+@Schema({ timestamps: true })
+export class Item extends Document {
+  @Prop({ type: Number, index: true, required: true })
+  itemId!: number;
+
+  @Prop({ type: String, required: true })
+  nameKR!: string;
+
+  @Prop({ type: Number, required: true })
+  count!: number;
+}
+
+export const ItemSchema = SchemaFactory.createForClass(Item);

--- a/libs/database/src/schemas/player.schema.ts
+++ b/libs/database/src/schemas/player.schema.ts
@@ -1,0 +1,18 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, HydratedDocument } from 'mongoose';
+
+export type PlayerDocument = HydratedDocument<Player>;
+
+@Schema({ timestamps: true })
+export class Player extends Document {
+  @Prop({ type: String, index: true, required: true, unique: true })
+  nickname!: string;
+
+  @Prop({ type: String, required: true })
+  password!: string;
+
+  @Prop({ type: Object, default: {} })
+  metadata!: Record<string, any>;
+}
+
+export const PlayerSchema = SchemaFactory.createForClass(Player);

--- a/libs/database/src/schemas/reward_package.schema.ts
+++ b/libs/database/src/schemas/reward_package.schema.ts
@@ -1,0 +1,24 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, HydratedDocument } from 'mongoose';
+
+export type RewardPackageDocument = HydratedDocument<RewardPackage>;
+
+@Schema({ timestamps: true })
+export class RewardPackage extends Document {
+  @Prop({ type: Number, index: true, required: true })
+  packageId!: number;
+
+  @Prop({ type: String, required: true })
+  nameKR!: string;
+
+  @Prop({ type: Number, required: true })
+  count!: number;
+
+  @Prop({ type: Boolean, default: false })
+  isActive!: boolean;
+
+  @Prop({ type: Object, default: {} })
+  metadata!: Record<string, any>;
+}
+
+export const RewardPackageSchema = SchemaFactory.createForClass(RewardPackage);

--- a/libs/interfaces/src/auth/player_login.dto.ts
+++ b/libs/interfaces/src/auth/player_login.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { BaseRequestDTO } from '../base.dto';
+import { IsObject, IsString } from 'class-validator';
+
+export class PlayerLoginRequestDto extends BaseRequestDTO {
+  @ApiProperty({
+    description: '닉네임',
+  })
+  @IsString()
+  nickname!: string;
+
+  @ApiProperty({
+    description: '패스워드',
+  })
+  @IsString()
+  password!: string;
+}
+export class PlayerLoginResponseDto {
+  @ApiProperty({
+    description: '닉네임',
+  })
+  @IsString()
+  nickname!: string;
+
+  @ApiProperty({
+    description: '플레이어 데이터',
+  })
+  @IsObject()
+  metadata!: Record<string, any>;
+
+  @ApiProperty({
+    description: '이벤트 보상 요청 토큰',
+  })
+  @IsString()
+  token!: string;
+}


### PR DESCRIPTION
- [feat(libs): player 스키마 및 요청/응답 Dto 추가](https://github.com/hank-128bit/nexon-game-event-system-mono/commit/96323f65ce7e1509f75d176b1ca120b67a259775)
- [feat(auth): 플레이어 모델 추가](https://github.com/hank-128bit/nexon-game-event-system-mono/commit/922d68f39c4e04dfd2433f73ddff1864e812aa2d)
- [feat(auth): 플레이어 로그인 메세지 패턴 함수 추가](https://github.com/hank-128bit/nexon-game-event-system-mono/commit/4afe2c4d7b640508e3c650bdf54e2766202208af)
- [feat(gw): 플레이어 로그인 API 추가 및 코드 중복 비대해져서 서비스 제네릭하게 수정](https://github.com/hank-128bit/nexon-game-event-system-mono/commit/27a325af27f25b87be7a5a0837dba166b82b60b9)
- [feat(libs): event, item, package, attendance 스키마 추가](https://github.com/hank-128bit/nexon-game-event-system-mono/commit/185987f7505101ae88d42587bbdcb308069bbe16)